### PR TITLE
Set the DOMPDF instance in Font_Metrics class.

### DIFF
--- a/src/Barryvdh/DomPDF/PDF.php
+++ b/src/Barryvdh/DomPDF/PDF.php
@@ -205,6 +205,8 @@ class PDF{
     protected function init(){
         $this->dompdf = new \DOMPDF();
         $this->dompdf->set_base_path(realpath(public_path()));
+        $canvas = \Canvas_Factory::get_instance($this->dompdf);
+        \Font_Metrics::init($canvas);
     }
 
     /**


### PR DESCRIPTION
Avoid error like `file_get_contents(/assets/my_font.woff): failed to open stream: No such file or directory` in `vendor/dompdf/dompdf/include/font_metrics.cls.php`.
Requirement: the pull request https://github.com/dompdf/dompdf/pull/796 need to be merged in DomPDF repositiory and a new release tagged.
