### PR TITLE
Call View::render explicitly in loadView.

### DIFF
--- a/src/Barryvdh/DomPDF/PDF.php
+++ b/src/Barryvdh/DomPDF/PDF.php
@@ -138,7 +138,7 @@ class PDF{
      * @return static
      */
     public function loadView($view, $data = array(), $mergeData = array(), $encoding = null){
-        $html = \View::make($view, $data, $mergeData);
+        $html = \View::make($view, $data, $mergeData)->render();
         $this->loadHTML($html, $encoding);
         return $this;
     }


### PR DESCRIPTION
Calling View::render explicitly provides better error output in case an exception is thrown when rendering the view, the actual exception message is shown, instead of vague "__toString() must not throw exception" error.
