### PR TITLE
Added pound symbol to entities

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -206,6 +206,7 @@ class PDF{
     protected function convertEntities($subject){
         $entities = array(
             '€' => '&#0128;',
+            '£' => '&pound;',
         );
 
         foreach($entities as $search => $replace){


### PR DESCRIPTION
I was receiving an issue: DOMDocument::loadHTML(): htmlParseEntityRef: no name in Entity because of a £ symbol in my html.
I think it will be very convenient to add the pound symbol to the $entities array because it isn't used in the web languages so there will be no issues to convert it at all times.