### PR TITLE
Added possibility to password protect the PDF

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -214,5 +214,14 @@ class PDF{
         }
         return $subject;
     }
-
+    
+    /**
+     * Set a password to open the PDF
+     *
+     * @param string $password
+     */
+    public function setEncryption($password) {
+        $this->render();
+        $this->dompdf->get_canvas()->get_cpdf()->setEncryption($password, $password);
+    }
 }


### PR DESCRIPTION
A password for opening the PDF can be set calling the setEncryption method.

Example:
$pdf = PDF::loadView('pdf.invoice', $data);
$pdf->setEncryption($password);
return $pdf->download('invoice.pdf');
