### PR TITLE
add DomPdf setOptions function to the Laravel Facade

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -131,7 +131,7 @@ class PDF{
      * @return static
      */
     public function setOptions(array $options) {
-        $options = Options($options);
+        $options = new Options($options);
         $this->dompdf->setOptions($options);
         return $this;
     }

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -2,6 +2,7 @@
 namespace Barryvdh\DomPDF;
 
 use Dompdf\Dompdf;
+use Dompdf\Options;
 use Exception;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Factory as ViewFactory;
@@ -121,6 +122,18 @@ class PDF{
     public function loadView($view, $data = array(), $mergeData = array(), $encoding = null){
         $html = $this->view->make($view, $data, $mergeData)->render();
         return $this->loadHTML($html, $encoding);
+    }
+
+    /**
+     * Set/Change an option in DomPdf
+     *
+     * @param array $options
+     * @return static
+     */
+    public function setOptions(array $options) {
+        $options = Options($options);
+        $this->dompdf->setOptions($options);
+        return $this;
     }
 
     /**


### PR DESCRIPTION
When you need to change settings on the fly in the dompdf class you can do this with the setoptions function.

For example: if I want to change the dpi for a specific pdf document that I am rendering:

``` php
PDF::setOptions(['dpi' => 150]);

//or inline
return PDF::setOptions(['dpi' => 150])->loadView('pdf.invoice', $data)->download('invoice.pdf');
```
