### PR TITLE
Allowing Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x",
+        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.X",
         "dompdf/dompdf": "^0.8"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.X",
+        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.x",
         "dompdf/dompdf": "^0.8"
     },
 


### PR DESCRIPTION
This will allow Laravel 5.5 while keeping the minimum php at 5.5.9 instead of 7.0.