### PR TITLE
Fix error with new PHP versions

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -201,7 +201,7 @@ class PDF{
 
         if ( $this->showWarnings ) {
             global $_dompdf_warnings;
-            if(count($_dompdf_warnings)){
+            if(!empty($_dompdf_warnings) && count($_dompdf_warnings)){
                 $warnings = '';
                 foreach ($_dompdf_warnings as $msg){
                     $warnings .= $msg . "\n";


### PR DESCRIPTION
'Parameter must be an array or an object that implements Countable'
Related to https://wiki.php.net/rfc/counting_non_countables