### PR TITLE
Change enable html5 parser variable to match Dompdf options key.

### DIFF
--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -257,7 +257,7 @@ return array(
         /**
          * Use the more-than-experimental HTML5 Lib parser
          */
-        "DOMPDF_ENABLE_HTML5PARSER" => false,
+        "DOMPDF_ENABLE_HTML5_PARSER" => false,
 
 
     ),


### PR DESCRIPTION
Currently it is not possible to set the enable_html5_parser option on Dompdf due to a missing character in the config key. 

I updated the config accordingly.