### PR TITLE
Remove new lines from html

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -220,6 +220,8 @@ class PDF{
         $entities = array(
             '€' => '&#0128;',
             '£' => '&pound;',
+            '\n' => '',
+            '\r' => '',
         );
 
         foreach($entities as $search => $replace){


### PR DESCRIPTION
Remove all \n and \r characters from html. This could fix the "No block-level parent found. Not good." error.

Possible fix for #413
