### PR TITLE
[0.5] support for laravel 5.3 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x|5.1.x|5.2.*|5.3.*",
+        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x",
         "dompdf/dompdf": "0.6.*"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x|5.1.x",
+        "illuminate/support": "5.0.x|5.1.x|5.2.*|5.3.*",
         "dompdf/dompdf": "0.6.*"
     },
 


### PR DESCRIPTION
A fix, for an issue with [laravel datatable](https://yajrabox.com/docs/laravel-datatables/6.0/installation) on Laravel 5.3.  This is because laravel datatable requires   `dompdf v.0.61` on Laravel 5.3.  Extending support for laravel 5.3 will allow both to run 