### PR TITLE
Append options to existing config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,11 @@
     "name": "barryvdh/laravel-dompdf",
     "description": "A DOMPDF Wrapper for Laravel",
     "license": "MIT",
-    "keywords": ["laravel", "dompdf", "pdf"],
+    "keywords": [
+        "laravel",
+        "dompdf",
+        "pdf"
+    ],
     "authors": [
         {
             "name": "Barry vd. Heuvel",
@@ -11,10 +15,9 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.x",
+        "illuminate/support": "5.*",
         "dompdf/dompdf": "^0.8"
     },
-
     "autoload": {
         "psr-4": {
             "Barryvdh\\DomPDF\\": "src"

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -131,7 +131,7 @@ class PDF{
      * @return static
      */
     public function setOptions(array $options) {
-        $options = array_merge( app()->make('dompdf.options'), $options );
+        $options = array_merge(app()->make('dompdf.options'), $options);
         $options = new Options($options);
         $this->dompdf->setOptions($options);
         return $this;

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -131,6 +131,7 @@ class PDF{
      * @return static
      */
     public function setOptions(array $options) {
+        $options = array_merge( app()->make('dompdf.options'), $options );
         $options = new Options($options);
         $this->dompdf->setOptions($options);
         return $this;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -87,4 +87,20 @@ class ServiceProvider extends IlluminateServiceProvider
         return array('dompdf', 'dompdf.options', 'dompdf.wrapper');
     }
 
+    /**
+     * Overriding the internal Laravel framework method
+     * Recursively merge the given configuration with the existing configuration.
+     *
+     * @param  string  $path
+     * @param  string  $key
+     * @return void
+     */
+
+    protected function mergeConfigFrom($path, $key)
+    {
+        $config = $this->app['config']->get($key, []);
+
+        $this->app['config']->set($key, array_merge_recursive(require $path, $config));
+    }
+
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -88,7 +88,7 @@ class ServiceProvider extends IlluminateServiceProvider
     }
 
     /**
-     * Overriding the internal Laravel framework method
+     * Overriding the internal Laravel framework method.
      * Recursively merge the given configuration with the existing configuration.
      *
      * @param  string  $path


### PR DESCRIPTION
This PR changes the behavior of `config/dompdf.php` and `setOptions` method of `PDF` class.

Currently, creating a custom config file or specifying options via `setOptions` method completely overrides all of the default options in `laravel-dompdf\config\dompdf.php`. With this PR the new options will be added to the existing options. In override cases, the new options will be preferred.