### PR TITLE
Support Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.x",
+        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.x|5.6.x",
         "dompdf/dompdf": "^0.8"
     },
 


### PR DESCRIPTION
This package is a basic service provider and facade. Those things aren't going to be changed in a 5.x version of Laravel. Just set the requirement to 5.x and prevent people having to wait every time Laravel is coming up to a release.

You can't even test future releases before they happen without forking.