### PR TITLE
Adding Laravel 5.7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.x|5.6.x",
+        "illuminate/support": "5.1.x|5.2.x|5.3.x|5.4.x|5.5.x|5.6.x|5.7.x",
         "dompdf/dompdf": "^0.8"
     },
 


### PR DESCRIPTION
From what I can tell there should not be any changes other than enabling the 5.7 Illuminate/support package.