### PR TITLE
Adding file size to browser download window

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -169,7 +169,8 @@ class PDF{
         $output = $this->output();
         return new Response($output, 200, array(
                 'Content-Type' => 'application/pdf',
-                'Content-Disposition' =>  'attachment; filename="'.$filename.'"'
+                'Content-Disposition' =>  'attachment; filename="'.$filename.'"',
+                'Content-Length' => strlen($output),
             ));
     }
 


### PR DESCRIPTION
This PR adds the actual file size while downloading the file, in the browser "Open/Save As" window.

Without patch
![before](https://user-images.githubusercontent.com/2536019/51049239-9abbf900-15cd-11e9-8614-abcec89e0b2f.jpg)

With patch
![after](https://user-images.githubusercontent.com/2536019/51049238-9abbf900-15cd-11e9-9584-fd32efa636d6.jpg)


