### PR TITLE
Do not call setPaper() within render()

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -30,8 +30,6 @@ class PDF{
     protected $view;
 
     protected $rendered = false;
-    protected $orientation;
-    protected $paper;
     protected $showWarnings;
     protected $public_path;
 
@@ -67,8 +65,6 @@ class PDF{
      * @return $this
      */
     public function setPaper($paper, $orientation = 'portrait'){
-        $this->paper = $paper;
-        $this->orientation = $orientation;
         $this->dompdf->setPaper($paper, $orientation);
         return $this;
     }
@@ -195,8 +191,6 @@ class PDF{
         if(!$this->dompdf){
             throw new Exception('DOMPDF not created yet');
         }
-
-        $this->dompdf->setPaper($this->paper, $this->orientation);
 
         $this->dompdf->render();
 


### PR DESCRIPTION
Should fix #259, #336 and #515.

The usage of `$this->paper` and `$this->orientation` looks a bit useless in `\Barryvdh\DomPDF\PDF`. It is only being used within the `\Barryvdh\DomPDF\PDF::setPaper()` and `\Barryvdh\DomPDF\PDF::render()` methods.

Both methods call `$this->dompdf->setPaper()`. The only problem here is when `$this->paper` is `null`, the `render()` call will reset the default config options.

Let me know if I misunderstood / missed something!