### PR TITLE
add addInfo method for dompdf's add_info

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -105,6 +105,19 @@ class PDF{
         $this->rendered = false;
         return $this;
     }
+    
+    /**
+     * Add metadata info
+     *
+     * @param array $info
+     * @return static
+     */
+    public function addInfo($info){
+        foreach($info as $name=>$value){
+            $this->dompdf->add_info($name, $value);
+        }
+        return $this;
+    }
 
     /**
      * Load a View and convert to HTML


### PR DESCRIPTION
dompdf operates metadata by using `add_info` but laravel-dompdf don't have one. This PR adds a wrapper for that.