### PR TITLE
distinct recursive merge for config files

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -140,6 +140,7 @@ class PDF{
      * @return static
      */
     public function setOptions(array $options) {
+        $options = array_merge(app()->make('dompdf.options'), $options);
         $options = new Options($options);
         $this->dompdf->setOptions($options);
         return $this;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -88,4 +88,62 @@ class ServiceProvider extends IlluminateServiceProvider
         return array('dompdf', 'dompdf.options', 'dompdf.wrapper');
     }
 
+    /**
+     * Overriding the internal Laravel framework method.
+     * Recursively merge the given configuration with the existing configuration.
+     *
+     * @param  string  $path
+     * @param  string  $key
+     * @return void
+     */
+
+    protected function mergeConfigFrom($path, $key)
+    {
+        $config = $this->app['config']->get($key, []);
+
+        $defaultConfig = require $path;
+
+        $this->app['config']->set($key, $this->array_merge_recursive_distinct($defaultConfig, $config));
+    }
+
+    /**
+    * array_merge_recursive does indeed merge arrays, but it converts values with duplicate
+    * keys to arrays rather than overwriting the value in the first array with the duplicate
+    * value in the second array, as array_merge does. I.e., with array_merge_recursive,
+    * this happens (documented behavior):
+    *
+    * array_merge_recursive(array('key' => 'org value'), array('key' => 'new value'));
+    *     => array('key' => array('org value', 'new value'));
+    *
+    * array_merge_recursive_distinct does not change the datatypes of the values in the arrays.
+    * Matching keys' values in the second array overwrite those in the first array, as is the
+    * case with array_merge, i.e.:
+    *
+    * array_merge_recursive_distinct(array('key' => 'org value'), array('key' => 'new value'));
+    *     => array('key' => array('new value'));
+    *
+    * Parameters are passed by reference, though only for performance reasons. They're not
+    * altered by this function.
+    *
+    * @param array $array1
+    * @param array $array2
+    * @return array
+    * @author Daniel <daniel (at) danielsmedegaardbuus (dot) dk>
+    * @author Gabriel Sobrinho <gabriel (dot) sobrinho (at) gmail (dot) com>
+    */
+    protected function array_merge_recursive_distinct(array &$array1, array &$array2)
+    {
+      $merged = $array1;
+    
+      foreach ($array2 as $key => &$value) {
+            if (is_array ($value) && isset($merged[$key]) && is_array($merged[$key])) {
+                $merged[$key] = $this->array_merge_recursive_distinct($merged[$key], $value);
+            } else {
+                $merged[$key] = $value;
+            }
+      }
+    
+      return $merged;
+    }
+
 }


### PR DESCRIPTION
Allow the user to customize some of the values in the `defines` array of `dompdf.php` config without overriding the entire `defines` value.

This PR is a fixed version of #428. I was not able to reopen #428, since I cleaned up the commit history and force-pushed my fork.

To summarize the use case: with this PR, you're able to partially customize the settings in the `defines` key of `dompdf.php` config. For example, to customize `defines.DOMPDF_DPI`, you currently need to include all of the keys from the default config file in your custom config file. In the new version, if you change `defines.DOMPDF_DPI`, other settings are pulled from the default ones.