### PR TITLE
added options param to output function.

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -159,14 +159,16 @@ class PDF
     /**
      * Output the PDF as a string.
      *
+     * @param array $options
+     *
      * @return string The rendered PDF as string
      */
-    public function output()
+    public function output($options = [])
     {
         if (!$this->rendered) {
             $this->render();
         }
-        return $this->dompdf->output();
+        return $this->dompdf->output($options);
     }
 
     /**

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -159,6 +159,11 @@ class PDF
     /**
      * Output the PDF as a string.
      *
+     * The options parameter controls the output. Accepted options are:
+     *
+     * 'compress' = > 1 or 0 - apply content stream compression, this is
+     *    on (1) by default
+     *
      * @param array $options
      *
      * @return string The rendered PDF as string


### PR DESCRIPTION
Original dompdf support options param in Dompdf::output() function. This is useful for using compress in normal PDF library and JPG output in GD library.