### PR TITLE
[RFC] changing the PDFs render method visiblity to public

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -215,7 +215,7 @@ class PDF
     /**
      * Render the PDF
      */
-    protected function render()
+    public function render()
     {
         if (!$this->dompdf) {
             throw new Exception('DOMPDF not created yet');


### PR DESCRIPTION
since some (eg canvas-) adjustments can only be made AFTER the PDF has been rendered
it would be very helfpul if the respective render method would be available in "userland"

more details about the request can be found at:

https://github.com/barryvdh/laravel-dompdf/issues/612

if applicable, it would be very helpful if you could explain why the method is currently marked as protected. I assume there are concerns about the integrity of the generated document?