### PR TITLE
Add PHPStan, fix violations

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,5 +47,8 @@ jobs:
         composer require "laravel/framework:${{ matrix.laravel }}" --no-update --no-progress
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress
 
+    - name: Run Static Analysis
+      run: composer phpstan
+
     - name: Execute Unit Tests
       run: composer test

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
     "scripts": {
         "test": "phpunit",
         "check-style": "phpcs -p --standard=psr12 src/",
-        "fix-style": "phpcbf -p --standard=psr12 src/"
+        "fix-style": "phpcbf -p --standard=psr12 src/",
+        "phpstan": "phpstan analyze --memory-limit=-1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require-dev": {
         "orchestra/testbench": "^4|^5|^6",
         "squizlabs/php_codesniffer": "^3.5",
-        "phpro/grumphp": "^1"
+        "phpro/grumphp": "^1",
+        "nunomaduro/larastan": "^0.7.10"
     },
     "autoload": {
         "psr-4": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -11,3 +11,12 @@ grumphp:
             ignore_patterns:
             - tests/
             triggered_by: [php]
+        phpstan:
+            autoload_file: ~
+            configuration: ~
+            level: null
+            force_patterns: [ ]
+            ignore_patterns: [ ]
+            triggered_by: [ 'php' ]
+            memory_limit: "-1"
+            use_grumphp_paths: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+includes:
+    - vendor/nunomaduro/larastan/extension.neon
+
+parameters:
+    paths:
+        - src
+        - tests
+    level: 8
+    ignoreErrors:
+        # This is a global alias that cannot be detected by Larastan.
+        - '#Call to static method loadHtml\(\) on an unknown class PDF\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
     paths:
         - src
         - tests
-    level: 5
+    level: 8
     ignoreErrors:
         # This is a global alias that cannot be detected by Larastan.
         - '#Call to static method loadHtml\(\) on an unknown class PDF\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
     paths:
         - src
         - tests
-    level: 8
+    level: 3
     ignoreErrors:
         # This is a global alias that cannot be detected by Larastan.
         - '#Call to static method loadHtml\(\) on an unknown class PDF\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
     paths:
         - src
         - tests
-    level: 3
+    level: 5
     ignoreErrors:
         # This is a global alias that cannot be detected by Larastan.
         - '#Call to static method loadHtml\(\) on an unknown class PDF\.#'

--- a/src/Facade.php
+++ b/src/Facade.php
@@ -33,6 +33,9 @@ class Facade extends IlluminateFacade
 
     /**
      * Resolve a new instance
+     * @param string $method
+     * @param array<mixed> $args
+     * @return mixed
      */
     public static function __callStatic($method, $args)
     {
@@ -55,7 +58,11 @@ class Facade extends IlluminateFacade
                 return $instance->$method($args[0], $args[1], $args[2], $args[3]);
 
             default:
-                return call_user_func_array(array($instance, $method), $args);
+                $callable = [$instance, $method];
+                if (! is_callable($callable)) {
+                    throw new \UnexpectedValueException("Method PDF::{$method}() does not exist.");
+                }
+                return call_user_func_array($callable, $args);
         }
     }
 }

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -2,6 +2,7 @@
 
 namespace Barryvdh\DomPDF;
 
+use Dompdf\Adapter\CPDF;
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use Exception;
@@ -179,7 +180,7 @@ class PDF
     /**
      * Save the PDF to a file
      *
-     * @param $filename
+     * @param string $filename
      * @return static
      */
     public function save($filename)
@@ -246,16 +247,20 @@ class PDF
         $this->rendered = true;
     }
 
-    public function setEncryption($password, $ownerpassword = '', $pc = []) 
+    public function setEncryption($password, $ownerpassword = '', $pc = [])
     {
-       if (!$this->dompdf) {
-           throw new Exception("DOMPDF not created yet");
-       }
-       $this->render();
-       return $this->dompdf->getCanvas()->get_cpdf()->setEncryption($password, $ownerpassword, $pc);
+        if (!$this->dompdf) {
+            throw new Exception("DOMPDF not created yet");
+        }
+        $this->render();
+        $canvas = $this->dompdf->getCanvas();
+        if (! $canvas instanceof CPDF) {
+            throw new \RuntimeException('Encryption is only supported when using CPDF');
+        }
+        $canvas->get_cpdf()->setEncryption($password, $ownerpassword, $pc);
     }
 
-    protected function convertEntities($subject) 
+    protected function convertEntities($subject)
     {
         if (false === $this->config->get('dompdf.convert_entities', true)) {
             return $subject;

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -225,10 +225,6 @@ class PDF
      */
     public function render()
     {
-        if (!$this->dompdf) {
-            throw new Exception('DOMPDF not created yet');
-        }
-
         $this->dompdf->render();
 
         if ($this->showWarnings) {
@@ -249,9 +245,6 @@ class PDF
 
     public function setEncryption($password, $ownerpassword = '', $pc = [])
     {
-        if (!$this->dompdf) {
-            throw new Exception("DOMPDF not created yet");
-        }
         $this->render();
         $canvas = $this->dompdf->getCanvas();
         if (! $canvas instanceof CPDF) {

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -32,8 +32,13 @@ class PDF
     /** @var \Illuminate\Contracts\View\Factory  */
     protected $view;
 
+    /** @var bool */
     protected $rendered = false;
+
+    /** @var bool */
     protected $showWarnings;
+
+    /** @var string */
     protected $public_path;
 
     /**
@@ -57,7 +62,7 @@ class PDF
      *
      * @return Dompdf
      */
-    public function getDomPDF()
+    public function getDomPDF(): Dompdf
     {
         return $this->dompdf;
     }
@@ -65,11 +70,9 @@ class PDF
     /**
      * Set the paper size (default A4)
      *
-     * @param string|array $paper
-     * @param string $orientation
-     * @return $this
+     * @param string|array<string> $paper
      */
-    public function setPaper($paper, $orientation = 'portrait')
+    public function setPaper($paper, string $orientation = 'portrait'): self
     {
         $this->dompdf->setPaper($paper, $orientation);
         return $this;
@@ -77,11 +80,8 @@ class PDF
 
     /**
      * Show or hide warnings
-     *
-     * @param bool $warnings
-     * @return $this
      */
-    public function setWarnings($warnings)
+    public function setWarnings(bool $warnings): self
     {
         $this->showWarnings = $warnings;
         return $this;
@@ -90,11 +90,9 @@ class PDF
     /**
      * Load a HTML string
      *
-     * @param string $string
-     * @param string $encoding Not used yet
-     * @return static
+     * @param string|null $encoding Not used yet
      */
-    public function loadHTML($string, $encoding = null)
+    public function loadHTML(string $string, ?string $encoding = null): self
     {
         $string = $this->convertEntities($string);
         $this->dompdf->loadHtml($string, $encoding);
@@ -104,11 +102,8 @@ class PDF
 
     /**
      * Load a HTML file
-     *
-     * @param string $file
-     * @return static
      */
-    public function loadFile($file)
+    public function loadFile(string $file): self
     {
         $this->dompdf->loadHtmlFile($file);
         $this->rendered = false;
@@ -117,11 +112,10 @@ class PDF
 
     /**
      * Add metadata info
-     *
-     * @param array $info
+     * @param array<string, string> $info
      * @return static
      */
-    public function addInfo($info)
+    public function addInfo(array $info): self
     {
         foreach ($info as $name => $value) {
             $this->dompdf->add_info($name, $value);
@@ -131,14 +125,11 @@ class PDF
 
     /**
      * Load a View and convert to HTML
-     *
-     * @param string $view
-     * @param array $data
-     * @param array $mergeData
-     * @param string $encoding Not used yet
-     * @return static
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $mergeData
+     * @param string|null $encoding Not used yet
      */
-    public function loadView($view, $data = array(), $mergeData = array(), $encoding = null)
+    public function loadView(string $view, array $data = [], array $mergeData = [], ?string $encoding = null): self
     {
         $html = $this->view->make($view, $data, $mergeData)->render();
         return $this->loadHTML($html, $encoding);
@@ -147,10 +138,9 @@ class PDF
     /**
      * Set/Change an option in DomPdf
      *
-     * @param array $options
-     * @return static
+     * @param array<string, mixed> $options
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): self
     {
         $options = new Options($options);
         $this->dompdf->setOptions($options);
@@ -165,25 +155,22 @@ class PDF
      * 'compress' = > 1 or 0 - apply content stream compression, this is
      *    on (1) by default
      *
-     * @param array $options
+     * @param array<string, int> $options
      *
      * @return string The rendered PDF as string
      */
-    public function output($options = [])
+    public function output(array $options = []): string
     {
         if (!$this->rendered) {
             $this->render();
         }
-        return $this->dompdf->output($options);
+        return (string) $this->dompdf->output($options);
     }
 
     /**
      * Save the PDF to a file
-     *
-     * @param string $filename
-     * @return static
      */
-    public function save($filename)
+    public function save(string $filename): self
     {
         $this->files->put($filename, $this->output());
         return $this;
@@ -191,39 +178,33 @@ class PDF
 
     /**
      * Make the PDF downloadable by the user
-     *
-     * @param string $filename
-     * @return \Illuminate\Http\Response
      */
-    public function download($filename = 'document.pdf')
+    public function download(string $filename = 'document.pdf'): Response
     {
         $output = $this->output();
-        return new Response($output, 200, array(
-                'Content-Type' => 'application/pdf',
-                'Content-Disposition' =>  'attachment; filename="' . $filename . '"',
-                'Content-Length' => strlen($output),
-            ));
+        return new Response($output, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' =>  'attachment; filename="' . $filename . '"',
+            'Content-Length' => strlen($output),
+        ]);
     }
 
     /**
      * Return a response with the PDF to show in the browser
-     *
-     * @param string $filename
-     * @return \Illuminate\Http\Response
      */
-    public function stream($filename = 'document.pdf')
+    public function stream(string $filename = 'document.pdf'): Response
     {
         $output = $this->output();
-        return new Response($output, 200, array(
+        return new Response($output, 200, [
             'Content-Type' => 'application/pdf',
             'Content-Disposition' =>  'inline; filename="' . $filename . '"',
-        ));
+        ]);
     }
 
     /**
      * Render the PDF
      */
-    public function render()
+    public function render(): void
     {
         $this->dompdf->render();
 
@@ -243,7 +224,8 @@ class PDF
         $this->rendered = true;
     }
 
-    public function setEncryption($password, $ownerpassword = '', $pc = [])
+    /** @param array<string> $pc */
+    public function setEncryption(string $password, string $ownerpassword = '', array $pc = []): void
     {
         $this->render();
         $canvas = $this->dompdf->getCanvas();
@@ -253,16 +235,16 @@ class PDF
         $canvas->get_cpdf()->setEncryption($password, $ownerpassword, $pc);
     }
 
-    protected function convertEntities($subject)
+    protected function convertEntities(string $subject): string
     {
         if (false === $this->config->get('dompdf.convert_entities', true)) {
             return $subject;
         }
 
-        $entities = array(
+        $entities = [
             '€' => '&euro;',
             '£' => '&pound;',
-        );
+        ];
 
         foreach ($entities as $search => $replace) {
             $subject = str_replace($search, $replace, $subject);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -23,7 +23,7 @@ class ServiceProvider extends IlluminateServiceProvider
      * @throws \Exception
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $configPath = __DIR__ . '/../config/dompdf.php';
         $this->mergeConfigFrom($configPath, 'dompdf');
@@ -33,6 +33,10 @@ class ServiceProvider extends IlluminateServiceProvider
 
             if ($defines) {
                 $options = [];
+                /**
+                 * @var string $key
+                 * @var mixed $value
+                 */
                 foreach ($defines as $key => $value) {
                     $key = strtolower(str_replace('DOMPDF_', '', $key));
                     $options[$key] = $value;
@@ -48,7 +52,11 @@ class ServiceProvider extends IlluminateServiceProvider
 
             $options = $app->make('dompdf.options');
             $dompdf = new Dompdf($options);
-            $dompdf->setBasePath(realpath(base_path('public')));
+            $path = realpath(base_path('public'));
+            if ($path === false) {
+                throw new \RuntimeException('Cannot resolve public path');
+            }
+            $dompdf->setBasePath($path);
 
             return $dompdf;
         });
@@ -61,15 +69,13 @@ class ServiceProvider extends IlluminateServiceProvider
 
     /**
      * Check if package is running under Lumen app
-     *
-     * @return bool
      */
-    protected function isLumen()
+    protected function isLumen(): bool
     {
         return Str::contains($this->app->version(), 'Lumen') === true;
     }
 
-    public function boot()
+    public function boot(): void
     {
         if (! $this->isLumen()) {
             $configPath = __DIR__ . '/../config/dompdf.php';
@@ -80,10 +86,10 @@ class ServiceProvider extends IlluminateServiceProvider
     /**
      * Get the services provided by the provider.
      *
-     * @return array
+     * @return array<string>
      */
-    public function provides()
+    public function provides(): array
     {
-        return array('dompdf', 'dompdf.options', 'dompdf.wrapper');
+        return ['dompdf', 'dompdf.options', 'dompdf.wrapper'];
     }
 }

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Response;
 
 class PdfTest extends TestCase
 {
-    public function testAlias()
+    public function testAlias(): void
     {
         $pdf = \PDF::loadHtml('<h1>Test</h1>');
         /** @var Response $response */
@@ -19,7 +19,7 @@ class PdfTest extends TestCase
         $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
     }
 
-    public function testDownload()
+    public function testDownload(): void
     {
         $pdf = Facade::loadHtml('<h1>Test</h1>');
         /** @var Response $response */
@@ -31,7 +31,7 @@ class PdfTest extends TestCase
         $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
     }
 
-    public function testStream()
+    public function testStream(): void
     {
         $pdf = Facade::loadHtml('<h1>Test</h1>');
         /** @var Response $response */
@@ -43,7 +43,7 @@ class PdfTest extends TestCase
         $this->assertEquals('inline; filename="test.pdf"', $response->headers->get('Content-Disposition'));
     }
 
-    public function testView()
+    public function testView(): void
     {
         $pdf = Facade::loadView('test');
         /** @var Response $response */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,11 +15,19 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         View::addLocation(__DIR__.'/views');
     }
 
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     * @return string[]
+     */
     protected function getPackageProviders($app)
     {
         return [ServiceProvider::class];
     }
 
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     * @return string[]
+     */
     protected function getPackageAliases($app)
     {
         return [


### PR DESCRIPTION
I have added PHPStan for static analysis. I have added a composer script to run it, modified the GrumPHP config to automatically run it, and modified the CI workflow so it gets run on along with the unit tests.

I have gone all out and immediately configured PHPStan level 8 (the strictest level). This means that bugs will be detected earlier, and it is virtually impossible to commit code with preventable errors (don't quote me on this 😝 ).

Most of the violations that I fixed were related to incomplete or faulty type hints. As the minimum version of this package is PHP 7.2, I've also taken the liberty of converting any docblock type hints, to PHP 7.2 supported native type hints.

There are also a few instances where an edgecase was not covered. This was caught by PHPStan and I have built a nice failure path.

---

I can imagine there are a few opinionated changes here. So feel free to give feedback on the direction of this PR.