### PR TITLE
Expose Dompdf setters on config for default values

### DIFF
--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -73,7 +73,7 @@ return array(
          * should be an absolute path.
          * This is only checked on command line call by dompdf.php, but not by
          * direct class use like:
-         * $dompdf = new DOMPDF();	$dompdf->load_html($htmldata); $dompdf->render(); $pdfdata = $dompdf->output();
+         * $dompdf = new DOMPDF(); $dompdf->load_html($htmldata); $dompdf->render(); $pdfdata = $dompdf->output();
          */
         "chroot" => realpath(base_path()),
 
@@ -244,5 +244,11 @@ return array(
         "enable_html5_parser" => false,
     ),
 
+    /**
+     * Set some default values for Dompdf setters when they aren't available on defines, but the methods
+     * exists on Dompdf class, example: 'set_http_context', 'set_callbacks', 'set_host', 'enable_caching'
+     */
+    'setters' => array(
 
+    ),
 );

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -58,6 +58,13 @@ class ServiceProvider extends IlluminateServiceProvider
             }
             $dompdf->setBasePath($path);
 
+            $defaults = $app['config']->get('dompdf.setters', []);
+            foreach ($defaults as $key => $value) {
+                if (in_array(substr($key, 0, 3), ['set', 'ena']) && method_exists($dompdf, $key)) {
+                    $dompdf->$key($value);
+                }
+            }
+
             return $dompdf;
         });
         $this->app->alias('dompdf', Dompdf::class);

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -55,4 +55,21 @@ class PdfTest extends TestCase
         $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
     }
 
+
+    public function testDompdfDefaultMethods(): void
+    {
+        $callback = function(){};
+        $context = stream_context_create(['ssl'=>['verify_peer' => false, 'verify_peer_name' => false, 'allow_self_signed' => true]]);
+        config(['dompdf.setters' => [
+            'set_http_context' => $context,
+            'set_callbacks' => [['event' => 'test', 'f' => $callback]],
+        ]]);
+
+        $pdf = Facade::loadView('test');
+
+        $this->assertEquals($context, $pdf->getDomPDF()->getHttpContext());
+        $this->assertEquals(['test' => [$callback]], $pdf->getDomPDF()->getCallbacks());
+
+    }
+
 }


### PR DESCRIPTION
Avoid duplicating code using `getDomPDF()` when are default configs, only set the default on config file

**Before:** duplicate code on every instance
```php
$pdf = PDF::getFacadeRoot();
$dompdf = $pdf->getDomPDF();
$dompdf->setHttpContext(stream_context_create([
    'ssl' => [
        'verify_peer' => FALSE, 'verify_peer_name' => FALSE, 'allow_self_signed'=> TRUE
    ],
]));
```
**After:** every instance has the default value
```php
// config/dompdf.php
    'setters' => array(
        'set_http_context' => stream_context_create([
            'ssl' => [
                'verify_peer' => FALSE, 'verify_peer_name' => FALSE, 'allow_self_signed'=> TRUE
            ]
        ]),
    ),
```

https://github.com/barryvdh/laravel-dompdf/issues/567#issuecomment-564509782
https://github.com/barryvdh/laravel-dompdf/issues/722#issuecomment-738109547