### PR TITLE
Replaced base_path('public') with public_path() in ServiceProvider

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -48,7 +48,7 @@ class ServiceProvider extends IlluminateServiceProvider
 
             $options = $app->make('dompdf.options');
             $dompdf = new Dompdf($options);
-            $dompdf->setBasePath(realpath(base_path('public')));
+            $dompdf->setBasePath(realpath(public_path()));
 
             return $dompdf;
         });


### PR DESCRIPTION
When using a custom public path `base_path('public')` isn't working. `public_path()` is a working replacement of this.