### PR TITLE
Replaced base_path('public') with public_path() in ServiceProvider

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -51,7 +51,7 @@ class ServiceProvider extends IlluminateServiceProvider
 
             $options = $app->make('dompdf.options');
             $dompdf = new Dompdf($options);
-            $path = realpath(base_path('public'));
+            $path = realpath(public_path());
             if ($path === false) {
                 throw new \RuntimeException('Cannot resolve public path');
             }


### PR DESCRIPTION
When using a custom public path `base_path('public')` isn't working. `public_path()` is a working replacement of this.