### PR TITLE
Method `setHttpContext` for avoid using `getDomPDF`

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -87,6 +87,17 @@ class PDF
     }
 
     /**
+     * Sets the HTTP context
+     *
+     * @param resource|array $httpContext
+     */
+    public function setHttpContext($httpContext)
+    {
+        $this->dompdf->setHttpContext($httpContext);
+        return $this;
+    }
+
+    /**
      * Load a HTML string
      *
      * @param string|null $encoding Not used yet


### PR DESCRIPTION
https://github.com/dompdf/dompdf/blob/116404a740f937cb40534fa559468206e5bf9023/src/Dompdf.php#L1236-L1246

If you use `getDomPDF` for `setHttpContext`, you can't keep concatenating methods

**Example:** 
```php
return PDF::loadView('pdf')
    ->setHttpContext(['ssl'=>['verify_peer'=>false, 'verify_peer_name'=>false, 'allow_self_signed'=>true]])
    ->stream();
```
**Before:**
```php
$pdf = PDF::loadView('pdf');
$pdf->getDomPDF()
    ->setHttpContext(
        stream_context_create(['ssl'=>['verify_peer'=>false, 'verify_peer_name'=>false, 'allow_self_signed'=>true]])
    );
return $pdf->stream();
```
