### PR TITLE
Use global config for `setHttpContext` stream

### DIFF
--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -13,6 +13,7 @@ return array(
     */
     'show_warnings' => false,   // Throw an Exception on warnings from dompdf
     'orientation' => 'portrait',
+    'http_context' => null, // see stream_context_create options (https://www.php.net/manual/en/context.php)
     /*
      * Dejavu Sans font is missing glyphs for converted entities, turn it off if you need to show € and £.
      */

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -57,6 +57,11 @@ class ServiceProvider extends IlluminateServiceProvider
             }
             $dompdf->setBasePath($path);
 
+            $httpContext = $app['config']->get('dompdf.http_context');
+            if (is_array($httpContext)) {
+                $dompdf->setHttpContext(stream_context_create($httpContext));
+            }
+
             return $dompdf;
         });
         $this->app->alias('dompdf', Dompdf::class);


### PR DESCRIPTION
Config key if you want to use same http context as default for all pdfs,
use name `http_context` for consistence

**Example:**  `config/dompdf.php`
```php
    ///
    'http_context'=>[
        'ssl' => [
            'verify_peer' => false,
            'verify_peer_name' => false,
            'allow_self_signed' => true
        ]
    ]
    ///
```

**Before:**
```php
$pdf = PDF::loadView('pdf');
$pdf->getDomPDF()
    ->setHttpContext(
        stream_context_create(['ssl'=>['verify_peer'=>false, 'verify_peer_name'=>false, 'allow_self_signed'=>true]])
    )
return $pdf->stream();
```