### PR TITLE
provide access to setCallbacks method

### DIFF
--- a/src/Facade/Pdf.php
+++ b/src/Facade/Pdf.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Facade as IlluminateFacade;
 
 /**
  * @method static \Barryvdh\DomPDF\PDF setPaper($paper, $orientation = 'portrait')
+ * @method static \Barryvdh\DomPDF\PDF setCallbacks(array $callbacks)
  * @method static \Barryvdh\DomPDF\PDF setWarnings($warnings)
  * @method static \Barryvdh\DomPDF\PDF setOptions(array $options)
  * @method static \Barryvdh\DomPDF\PDF loadView($view, $data = array(), $mergeData = array(), $encoding = null)

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -78,6 +78,17 @@ class PDF
     }
 
     /**
+     * Set callbacks
+     *
+     * @param array<array> $callbacks
+     */
+    public function setCallbacks(array $callbacks): self
+    {
+        $this->dompdf->setCallbacks($callbacks);
+        return $this;
+    }
+
+    /**
      * Show or hide warnings
      */
     public function setWarnings(bool $warnings): self


### PR DESCRIPTION
Just open access to ```setCallbacks``` method. Use case:
```php
        $pdf = Pdf::loadView(...)->setCallbacks([
            [
                'event' => 'end_frame',
                'f' => function ($info) {
                    $frame = $info['frame'];
                    /** @var CPDF $canvas */
                    $canvas = $info['canvas'];
                    /** @var DOMElement $node */
                    $node = $frame->get_node();
                    if ($node->nodeName === 'a') {
                        $href = $node->getAttribute('href');
                        if (strpos($href, 'file://') === 0) {
                            $url = substr($href, 7);
                            foreach ($canvas->get_cpdf()->objects as $key => $object) {
                                if ($object['type'] ?? '' === 'URI') {
                                    if (strpos($object['info'] ?? '', $url) !== false) {
                                        $canvas->get_cpdf()->objects[$key]['info'] = $url;
                                        break;
                                    }
                                }
                            }
                        }
                    }
                }
            ]
        ]);
```