### PR TITLE
Config option for custom public path

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -51,7 +51,7 @@ class ServiceProvider extends IlluminateServiceProvider
 
             $options = $app->make('dompdf.options');
             $dompdf = new Dompdf($options);
-            $path = realpath(base_path('public'));
+            $path = realpath($app['config']->get('dompdf.public_path') ?: base_path('public'));
             if ($path === false) {
                 throw new \RuntimeException('Cannot resolve public path');
             }


### PR DESCRIPTION
Alternative to https://github.com/barryvdh/laravel-dompdf/pull/867 Fixes https://github.com/barryvdh/laravel-dompdf/issues/868
> When using a custom public path `base_path('public')` isn't working. `public_path()` is a working replacement of this.