### PR TITLE
Magic methods for DOMPDF instance

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,7 @@ jobs:
       COMPOSER_NO_INTERACTION: 1
 
     strategy:
+      fail-fast: false
       matrix:
         php: [8.0, 7.4, 7.3, 7.2]
         laravel: [8.*, 7.*, 6.*]

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,5 @@ parameters:
     ignoreErrors:
         # This is a global alias that cannot be detected by Larastan.
         - '#Call to static method loadHtml\(\) on an unknown class PDF\.#'
+        # This is a magic method that cannot be detected by Larastan.
+        - '#Call to an undefined method Dompdf\\Dompdf::loadView\(\)\.#'

--- a/src/Facade/Pdf.php
+++ b/src/Facade/Pdf.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Facades\Facade as IlluminateFacade;
 
 /**
  * @method static \Barryvdh\DomPDF\PDF setPaper($paper, $orientation = 'portrait')
+ * @method static \Barryvdh\DomPDF\PDF setBaseHost(string $baseHost)
+ * @method static \Barryvdh\DomPDF\PDF setProtocol(string $protocol)
+ * @method static \Barryvdh\DomPDF\PDF setHttpContext($httpContext)
+ * @method static \Barryvdh\DomPDF\PDF setCallbacks(array $callbacks)
  * @method static \Barryvdh\DomPDF\PDF setWarnings($warnings)
  * @method static \Barryvdh\DomPDF\PDF setOptions(array $options)
  * @method static \Barryvdh\DomPDF\PDF loadView($view, $data = array(), $mergeData = array(), $encoding = null)

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -16,6 +16,8 @@ use Illuminate\Http\Response;
  *
  * @package laravel-dompdf
  * @author Barry vd. Heuvel
+ *
+ * @mixin \Dompdf\Dompdf
  */
 class PDF
 {
@@ -249,5 +251,27 @@ class PDF
             $subject = str_replace($search, $replace, $subject);
         }
         return $subject;
+    }
+
+    /**
+     * Dynamically handle calls into the dompdf instance.
+     *
+     * @param string $method
+     * @param array<mixed> $parameters
+     * @return $this|mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (method_exists($this, $method)) {
+            return $this->$method(...$parameters);
+        }
+
+        if (method_exists($this->dompdf, $method)) {
+            $return = $this->dompdf->$method(...$parameters);
+
+            return $return == $this->dompdf ? $this : $return;
+        }
+
+        throw new \UnexpectedValueException("Method [{$method}] does not exist on PDF instance.");
     }
 }

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -79,4 +79,22 @@ class PdfTest extends TestCase
         $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
     }
 
+    public function testMagicMethods(): void
+    {
+        $pdf = Facade::setBaseHost('host')->setProtocol('protocol')
+            ->loadView('test')->setOptions(['temp_dir' => 'test_dir'])
+            ->setHttpContext(['ssl' => []]);
+        /** @var Response $response */
+        $response = $pdf->download('test.pdf');
+
+        $this->assertInstanceOf(\Barryvdh\DomPDF\PDF::class, $pdf);
+        $this->assertEquals('host', $pdf->getDomPDF()->getBaseHost());
+        $this->assertEquals('host', $pdf->getBaseHost());
+        $this->assertEquals('protocol', $pdf->getDomPDF()->getProtocol());
+        $this->assertEquals('protocol', $pdf->getProtocol());
+        $this->assertEquals('test_dir', $pdf->getOptions()->getTempDir());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertNotEmpty($response->getContent());
+    }
 }


### PR DESCRIPTION
is possible to provide access to all dompdf methods using `__call` magic method?
This PR avoid adding a method wrapper for each dompdf method

- #888
- #871

Those PRs will be avoid if this PR is posible

Also, after this, `setPaper` could be deleted
https://github.com/barryvdh/laravel-dompdf/blob/cdd499077e431a833ab59b2837d218c86f093969/src/PDF.php#L74-L78

---
**UPDATE:** Test and phpDoc added