### PR TITLE
Support custom disks saving

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -10,6 +10,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * A Laravel wrapper for Dompdf
@@ -174,8 +175,15 @@ class PDF
     /**
      * Save the PDF to a file
      */
-    public function save(string $filename): self
+    public function save(string $filename, string $disk = null): self
     {
+        $disk = $disk ?: $this->config->get('dompdf.disk');
+
+        if (! is_null($disk)) {
+            Storage::disk($disk)->put($filename, $this->output());
+            return $this;
+        }
+
         $this->files->put($filename, $this->output());
         return $this;
     }

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -4,6 +4,7 @@ namespace Barryvdh\DomPDF\Tests;
 
 use Barryvdh\DomPDF\Facade;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
 
 class PdfTest extends TestCase
 {
@@ -77,6 +78,22 @@ class PdfTest extends TestCase
         $this->assertNotEmpty($response->getContent());
         $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
         $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+    }
+
+    public function testSaveOnDisk(): void
+    {
+        $disk_name = 'local';
+        $disk = Storage::disk($disk_name);
+        $filename = 'my_stored_file_on_disk.pdf';
+
+        $pdf = Facade\Pdf::loadView('test');
+        $pdf->save($filename, $disk_name);
+
+        $this->assertTrue($disk->exists($filename));
+
+        $content = $disk->get($filename);
+        $this->assertNotEmpty($content);
+        $this->assertEquals($content, $pdf->output());
     }
 
     public function testMagicMethods(): void


### PR DESCRIPTION
Closes #908
Example
```php
// keeps old functionality
$pdf->save('relative_path/file.pdf');
$pdf->save('/absolute_path/file.pdf');
// adds new functionality
$pdf->save('file.pdf', 's3');
$pdf->save('file.pdf', 'local');
```