### PR TITLE
Fix named arguments when using facade

### DIFF
--- a/src/Facade/Pdf.php
+++ b/src/Facade/Pdf.php
@@ -34,39 +34,4 @@ class Pdf extends IlluminateFacade
     {
         return 'dompdf.wrapper';
     }
-
-    /**
-     * Resolve a new instance
-     * @param string $method
-     * @param array<mixed> $args
-     * @return mixed
-     */
-    public static function __callStatic($method, $args)
-    {
-        $instance = static::$app->make(static::getFacadeAccessor());
-
-        switch (count($args)) {
-            case 0:
-                return $instance->$method();
-
-            case 1:
-                return $instance->$method($args[0]);
-
-            case 2:
-                return $instance->$method($args[0], $args[1]);
-
-            case 3:
-                return $instance->$method($args[0], $args[1], $args[2]);
-
-            case 4:
-                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
-
-            default:
-                $callable = [$instance, $method];
-                if (! is_callable($callable)) {
-                    throw new \UnexpectedValueException("Method PDF::{$method}() does not exist.");
-                }
-                return call_user_func_array($callable, $args);
-        }
-    }
 }


### PR DESCRIPTION
## About
Named arguments don't work when using facade because of hardcoded args in `__callStatic()`

---

**Reproduce the problem:**
```php
Pdf::loadView('pdf.report', [
    ...
], encoding: 'UTF-8')->output();
```

**Then we get:**

![error](https://user-images.githubusercontent.com/37669560/192477181-c159be61-5ab2-4025-8873-993bc916eb93.png)

---

I've removed the magic method and the named arguments now work as expected, but I'm wondering if there was a special reason to add this code? All tests pass after the change:

---

![scr](https://user-images.githubusercontent.com/37669560/192477946-ca21aadb-0005-4a21-bc4d-19085a7ea99c.png)

---