### PR TITLE
Laravel 10.x support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,12 @@ jobs:
         laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 10.*
+            php: 8.2
+            dependency-version: prefer-stable
+          - laravel: 10.*
+            php: 8.1
+            dependency-version: prefer-stable
           - laravel: 9.*
             php: 8.2
             dependency-version: prefer-stable

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "dompdf/dompdf": "^2.0.1",
-        "illuminate/support": "^6|^7|^8|^9"
+        "illuminate/support": "^6|^7|^8|^9|^10"
     },
     "require-dev": {
-        "orchestra/testbench": "^4|^5|^6|^7",
+        "orchestra/testbench": "^4|^5|^6|^7|^8",
         "squizlabs/php_codesniffer": "^3.5",
         "phpro/grumphp": "^1",
         "nunomaduro/larastan": "^1|^2"


### PR DESCRIPTION
It is already working on Laravel 10.x, tested with `"prefer-stable": false,`
```
- Upgrading orchestra/testbench (v7.6.1 => 8.x-dev 836757a): Extracting archive
- Upgrading nunomaduro/larastan (v2.1.12 => 2.4.0): Extracting archive
- Upgrading laravel/framework (v9.24.0 => 10.x-dev 57c79aa): Extracting archive
```
```batch
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.2
Configuration: /laravel-dompdf/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.........                                                           9 / 9 (100%)

Time: 00:00.468, Memory: 24.00 MB

OK ( 9 tests, 38 assertions)
```