### PR TITLE
bump dompdf to 2.0.3 for CVE-2023-23924

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,58 +1,58 @@
 {
-	"name": "barryvdh/laravel-dompdf",
-	"description": "A DOMPDF Wrapper for Laravel",
-	"license": "MIT",
-	"keywords": ["laravel", "dompdf", "pdf"],
-	"authors": [
-		{
-			"name": "Barry vd. Heuvel",
-			"email": "barryvdh@gmail.com"
-		}
-	],
-	"require": {
-		"php": "^7.2 || ^8.0",
-		"dompdf/dompdf": "^2.0.3",
-		"illuminate/support": "^6|^7|^8|^9|^10"
-	},
-	"require-dev": {
-		"orchestra/testbench": "^4|^5|^6|^7|^8",
-		"squizlabs/php_codesniffer": "^3.5",
-		"phpro/grumphp": "^1",
-		"nunomaduro/larastan": "^1|^2"
-	},
-	"autoload": {
-		"psr-4": {
-			"Barryvdh\\DomPDF\\": "src"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Barryvdh\\DomPDF\\Tests\\": "tests"
-		}
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "2.0-dev"
-		},
-		"laravel": {
-			"providers": ["Barryvdh\\DomPDF\\ServiceProvider"],
-			"aliases": {
-				"Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf",
-				"PDF": "Barryvdh\\DomPDF\\Facade\\Pdf"
-			}
-		}
-	},
-	"scripts": {
-		"test": "phpunit",
-		"check-style": "phpcs -p --standard=psr12 src/",
-		"fix-style": "phpcbf -p --standard=psr12 src/",
-		"phpstan": "phpstan analyze --memory-limit=-1"
-	},
-	"minimum-stability": "dev",
-	"prefer-stable": true,
-	"config": {
-		"allow-plugins": {
-			"phpro/grumphp": true
-		}
-	}
+    "name": "barryvdh/laravel-dompdf",
+    "description": "A DOMPDF Wrapper for Laravel",
+    "license": "MIT",
+    "keywords": ["laravel", "dompdf", "pdf"],
+    "authors": [
+        {
+            "name": "Barry vd. Heuvel",
+            "email": "barryvdh@gmail.com"
+        }
+    ],
+    "require": {
+        "php": "^7.2 || ^8.0",
+        "dompdf/dompdf": "^2.0.3",
+        "illuminate/support": "^6|^7|^8|^9|^10"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^4|^5|^6|^7|^8",
+        "squizlabs/php_codesniffer": "^3.5",
+        "phpro/grumphp": "^1",
+        "nunomaduro/larastan": "^1|^2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Barryvdh\\DomPDF\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Barryvdh\\DomPDF\\Tests\\": "tests"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        },
+        "laravel": {
+            "providers": ["Barryvdh\\DomPDF\\ServiceProvider"],
+            "aliases": {
+                "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf"
+            }
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "check-style": "phpcs -p --standard=psr12 src/",
+        "fix-style": "phpcbf -p --standard=psr12 src/",
+        "phpstan": "phpstan analyze --memory-limit=-1"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "phpro/grumphp": true
+        }
+    }
 }


### PR DESCRIPTION
Increased dompdf version to 2.0.3 for security vulnerability.

[CVE-2023-23924](https://nvd.nist.gov/vuln/detail/CVE-2023-23924#match-8863864)