### PR TITLE
Bump dompdf/dompdf to 2.0.3 for the CVE-2023-23924

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "dompdf/dompdf": "^2.0.1",
+        "dompdf/dompdf": "^2.0.3",
         "illuminate/support": "^6|^7|^8|^9|^10"
     },
     "require-dev": {


### PR DESCRIPTION
Bump dompdf/dompdf to 2.0.3 for the CVE-2023-23924

https://nvd.nist.gov/vuln/detail/CVE-2023-23924#match-8863864