### PR TITLE
Fix setOptions method

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -142,13 +142,13 @@ class PDF
     /**
      * Replace all the Options from DomPDF
      *
-     * @deprecated Use setOption to override individual options.
      * @param array<string, mixed> $options
      */
     public function setOptions(array $options): self
     {
-        $options = new Options($options);
-        $this->dompdf->setOptions($options);
+        $dompdfOptions = new Options(app()->make('dompdf.options'));
+        $dompdfOptions->set($options);
+        $this->dompdf->setOptions($dompdfOptions);
         return $this;
     }
 

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -96,6 +96,24 @@ class PdfTest extends TestCase
         $this->assertEquals($content, $pdf->output());
     }
 
+    public function testConfigOptions(): void
+    {
+        \Config::set('dompdf.options.default_font', 'default_font');
+        \Config::set('dompdf.options.log_output_file', 'default_log');
+
+        $pdf = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        $this->assertEquals('default_font', $pdf->getDomPDF()->getOptions()->getDefaultFont());
+        $this->assertEquals('default_log', $pdf->getDomPDF()->getOptions()->getLogOutputFile());
+
+        $pdf->setOption('default_font', 'custom_font');
+        $this->assertEquals('custom_font', $pdf->getDomPDF()->getOptions()->getDefaultFont());
+        $this->assertEquals('default_log', $pdf->getDomPDF()->getOptions()->getLogOutputFile());
+
+        $pdf->setOptions([]); // reset options to config/dompdf.php
+        $this->assertEquals('default_font', $pdf->getDomPDF()->getOptions()->getDefaultFont());
+        $this->assertEquals('default_log', $pdf->getDomPDF()->getOptions()->getLogOutputFile());
+    }
+
     public function testMagicMethods(): void
     {
         $pdf = Facade\Pdf::setBaseHost('host')->setProtocol('protocol')


### PR DESCRIPTION
I think it is not necessary to deprecate the `setOptions` method, the problem was that it removed all the default settings, but with `app()->make('dompdf.options')` we get a copy of `config/dompdf.php` before adding the options, the functionality is maintained and it is shorter to use than the original method
https://github.com/dompdf/dompdf/blob/56a660ce045ee27c84154c60b612c936ddb86398/src/Dompdf.php#L1327
Also with an empty array we could reset options to default `config/dompdf.php` config, example: `$pdf->setOptions([])`

Closes https://github.com/barryvdh/laravel-dompdf/issues/793#issuecomment-866519800

**UPDATE:** Test added
