### PR TITLE
Fix named arguments when using facade

### DIFF
--- a/src/Facade/Pdf.php
+++ b/src/Facade/Pdf.php
@@ -45,28 +45,6 @@ class Pdf extends IlluminateFacade
     {
         $instance = static::$app->make(static::getFacadeAccessor());
 
-        switch (count($args)) {
-            case 0:
-                return $instance->$method();
-
-            case 1:
-                return $instance->$method($args[0]);
-
-            case 2:
-                return $instance->$method($args[0], $args[1]);
-
-            case 3:
-                return $instance->$method($args[0], $args[1], $args[2]);
-
-            case 4:
-                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
-
-            default:
-                $callable = [$instance, $method];
-                if (! is_callable($callable)) {
-                    throw new \UnexpectedValueException("Method PDF::{$method}() does not exist.");
-                }
-                return call_user_func_array($callable, $args);
-        }
+        return $instance->$method(...$args);
     }
 }

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -127,4 +127,16 @@ class PdfTest extends TestCase
         $this->assertNotEmpty($content);
         $this->assertEquals($content, $pdf->output());
     }
+
+    public function testMultipleInstances(): void
+    {
+        $pdf1 = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        $pdf2 = Facade\Pdf::loadHtml('<h1>Test</h1>');
+
+        $pdf1->getDomPDF()->setBaseHost('host1');
+        $pdf2->getDomPDF()->setBaseHost('host2');
+
+        $this->assertEquals('host1', $pdf1->getDomPDF()->getBaseHost());
+        $this->assertEquals('host2', $pdf2->getDomPDF()->getBaseHost());
+    }
 }


### PR DESCRIPTION
>Named arguments don't work when using facade because of hardcoded args in `__callStatic()`

Alternative to #921
Demo: https://onlinephp.io/c/d34c3
[lluminate/Support/Facades/Facade.php#L345-L353](https://github.com/laravel/framework/blob/4b22e39a058a6e91418bf080c923eb6021295287/src/Illuminate/Support/Facades/Facade.php#L345-L353)
> I think there was a reason for this. But not 100% sure, probably with regards to multiple instances. https://github.com/barryvdh/laravel-dompdf/pull/921#issuecomment-1297140042

This PR keeps multiple instances functionality

----
facade method conditional is no longer necessary, because it always pass thru, and PDF already validates that
https://github.com/barryvdh/laravel-dompdf/blob/3dbe06b2dd1e5b647a07f464cee9965d4f14645d/src/Facade/Pdf.php#L66-L68
https://github.com/barryvdh/laravel-dompdf/blob/3dbe06b2dd1e5b647a07f464cee9965d4f14645d/src/PDF.php#L286

