### PR TITLE
Fix config key for allowed protocols

### DIFF
--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -90,7 +90,7 @@ return array(
          *
          * @var array
          */
-        'allowed_protocols' => [
+        'allowedProtocols' => [
             "file://" => ["rules" => []],
             "http://" => ["rules" => []],
             "https://" => ["rules" => []]


### PR DESCRIPTION
dompdf expects camel case instead of snake case for this specific option as seen [here](https://github.com/dompdf/dompdf/blob/5d0ca14b78e03040a6720bd7f2d72691047a47ab/src/Options.php#L362).