### PR TITLE
Upgrade to larastan/larastan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "orchestra/testbench": "^4|^5|^6|^7|^8",
         "squizlabs/php_codesniffer": "^3.5",
         "phpro/grumphp": "^1",
-        "nunomaduro/larastan": "^1|^2"
+        "larastan/larastan": "^2.7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
 
 parameters:
     reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
Abandoned warning

`Package nunomaduro/larastan is abandoned, you should avoid using it. Use larastan/larastan instead.`