### PR TITLE
Encode filename when downloading

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -210,7 +210,7 @@ class PDF
         $output = $this->output();
         return new Response($output, 200, [
             'Content-Type' => 'application/pdf',
-            'Content-Disposition' =>  'attachment; filename="' . $filename . '"',
+            'Content-Disposition' =>  'attachment; filename="' . rawurlencode($filename) . '"',
             'Content-Length' => strlen($output),
         ]);
     }


### PR DESCRIPTION
Encode the filename according to RFC 3986 when downloading the file.

We had problems with umlauts in the filename, when we deployed a project with Vapor. Locally it worked fine, but when deployed, all umlauts got replaced with underscores.

We tried a few things that did not work, so we went on and asked Chat GPT which suggested using `rawurlencode`. This fixed the Problem.

`rawurlencode` can also be used on environments that did not show this problem.