### PR TITLE
Update dompdf to fix GHSA-3qx2-6f78-w2j2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "dompdf/dompdf": "^2.0.3",
+        "dompdf/dompdf": "^2.0.4",
         "illuminate/support": "^6|^7|^8|^9|^10"
     },
     "require-dev": {


### PR DESCRIPTION
A security fix is shipped on dompdf last version, that should probably be applied there.