### PR TITLE
Laravel 11 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,12 @@ jobs:
         laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 11.*
+            php: 8.3
+            dependency-version: prefer-stable
+          - laravel: 11.*
+            php: 8.2
+            dependency-version: prefer-stable
           - laravel: 10.*
             php: 8.2
             dependency-version: prefer-stable

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "dompdf/dompdf": "^2.0.3",
-        "illuminate/support": "^6|^7|^8|^9|^10"
+        "illuminate/support": "^6|^7|^8|^9|^10|^11"
     },
     "require-dev": {
-        "orchestra/testbench": "^4|^5|^6|^7|^8",
+        "orchestra/testbench": "^4|^5|^6|^7|^8|^9",
         "squizlabs/php_codesniffer": "^3.5",
         "phpro/grumphp": "^1",
         "larastan/larastan": "^1.0|^2.7.0"

--- a/src/Facade/Pdf.php
+++ b/src/Facade/Pdf.php
@@ -4,6 +4,7 @@ namespace Barryvdh\DomPDF\Facade;
 
 use Barryvdh\DomPDF\PDF as BasePDF;
 use Illuminate\Support\Facades\Facade as IlluminateFacade;
+use RuntimeException;
 
 /**
  * @method static BasePDF setBaseHost(string $baseHost)
@@ -43,14 +44,24 @@ class Pdf extends IlluminateFacade
     }
 
     /**
-     * Resolve a new instance
+     * Handle dynamic, static calls to the object.
+     *
      * @param string $method
      * @param array<mixed> $args
      * @return mixed
+     *
+     * @throws \RuntimeException
      */
     public static function __callStatic($method, $args)
     {
-        $instance = static::$app->make(static::getFacadeAccessor());
+        /** @var \Illuminate\Contracts\Foundation\Application|null */
+        $app = static::getFacadeApplication();
+        if (! $app) {
+            throw new RuntimeException('Facade application has not been set.');
+        }
+
+        // Resolve a new instance, avoid using a cached instance
+        $instance = $app->make(static::getFacadeAccessor());
 
         return $instance->$method(...$args);
     }


### PR DESCRIPTION
Closes #1034

----
**Ref:** https://github.com/laravel/framework/pull/50260
PhpStan fails on Laravel 10.x, I could add a baseline rule
```batch
Error: Cannot call method make() on Illuminate\Contracts\Foundation\Application|null.
 ------ --------------------------------------------------- 
  Line   src/Facade/Pdf.php                                 
 ------ --------------------------------------------------- 
  53     Cannot call method make() on                       
         Illuminate\Contracts\Foundation\Application|null.  
 ------ --------------------------------------------------- 
```