### PR TITLE
Only support DomPDF 3

### DIFF
--- a/.github/workflows/run-static-analysis.yml
+++ b/.github/workflows/run-static-analysis.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
+        laravel: [9.*, 10.*, 11.*]
         dependency-version: [prefer-stable]
         exclude:
           - laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,53 +22,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.2]
-        laravel: ['6.*', '7.*', '8.*', '11.*']
+        php: [8.1, 8.2, 8.3]
+        laravel: ['9.*', '10.*', '11.*']
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 11.*
-            php: 8.3
-            dependency-version: prefer-stable
-          - laravel: 11.*
-            php: 8.2
-            dependency-version: prefer-stable
-          - laravel: 10.*
-            php: 8.3
-            dependency-version: prefer-stable
-          - laravel: 10.*
-            php: 8.2
-            dependency-version: prefer-stable
-          - laravel: 10.*
-            php: 8.1
-            dependency-version: prefer-stable
-          - laravel: 9.*
-            php: 8.2
-            dependency-version: prefer-stable
-          - laravel: 9.*
-            php: 8.1
-            dependency-version: prefer-stable
-          - laravel: 9.*
-            php: 8.0
-            dependency-version: prefer-stable
         exclude:
-          - laravel: 8.*
-            php: 7.2
-          - laravel: 6.*
-            php: 8.2
-          - laravel: 7.*
-            php: 8.2
-          - laravel: 8.*
-            php: 8.2
-          - php: 8.0
-            dependency-version: prefer-lowest
           - laravel: 11.*
-            php: 7.2
-          - laravel: 11.*
-            php: 7.3
-          - laravel: 11.*
-            php: 7.4
-          - laravel: 11.*
-            php: 8.0
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+[3.0.0]
+Version 3.x supports DomPDF version 3.x. See the changelog in https://github.com/dompdf/dompdf/releases/tag/v3.0.0
+
+The most notable change in laravel-dompdf are the changed defaults, to be more secure;
+ - `enable_remote` is now `false` by default. Change with caution.
+ - `allowedRemoteHosts` and `artifactPathValidation` are added the the config.
+Also, support for Laravel < 9 and PHP < 8.1 is dropped.
 
 [2.2.0]
 ## What's Changed

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "3.0-dev"
         },
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
-        "dompdf/dompdf": "^2.0.7 || ^3.0",
-        "illuminate/support": "^6|^7|^8|^9|^10|^11"
+        "php": "^8.1",
+        "dompdf/dompdf": "^3.0",
+        "illuminate/support": "^9|^10|^11"
     },
     "require-dev": {
-        "orchestra/testbench": "^4|^5|^6|^7|^8|^9",
+        "orchestra/testbench": "^7|^8|^9",
         "squizlabs/php_codesniffer": "^3.5",
-        "phpro/grumphp": "^1 || ^2.5",
-        "larastan/larastan": "^1.0|^2.7.0"
+        "phpro/grumphp": "^2.5",
+        "larastan/larastan": "^2.7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "dompdf/dompdf": "^2.0.7",
+        "dompdf/dompdf": "^2.0.7 || ^3.0",
         "illuminate/support": "^6|^7|^8|^9|^10|^11"
     },
     "require-dev": {

--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -142,20 +142,6 @@ return array(
         "pdf_backend" => "CPDF",
 
         /**
-         * PDFlib license key
-         *
-         * If you are using a licensed, commercial version of PDFlib, specify
-         * your license key here.  If you are using PDFlib-Lite or are evaluating
-         * the commercial version of PDFlib, comment out this setting.
-         *
-         * @link http://www.pdflib.com
-         *
-         * If pdflib present in web server and auto or selected explicitely above,
-         * a real license code must exist!
-         */
-        //"DOMPDF_PDFLIB_LICENSE" => "your license key here",
-
-        /**
          * html target media view which should be rendered into pdf.
          * List of types and parsing rules for future extensions:
          * http://www.w3.org/TR/REC-html40/types.html
@@ -229,24 +215,31 @@ return array(
         "dpi" => 96,
 
         /**
-         * Enable inline PHP
+         * Enable embedded PHP
          *
-         * If this setting is set to true then DOMPDF will automatically evaluate
-         * inline PHP contained within <script type="text/php"> ... </script> tags.
+         * If this setting is set to true then DOMPDF will automatically evaluate embedded PHP contained
+         * within <script type="text/php"> ... </script> tags.
          *
-         * Enabling this for documents you do not trust (e.g. arbitrary remote html
-         * pages) is a security risk.  Set this option to false if you wish to process
-         * untrusted documents.
+         * ==== IMPORTANT ==== Enabling this for documents you do not trust (e.g. arbitrary remote html pages)
+         * is a security risk.
+         * Embedded scripts are run with the same level of system access available to dompdf.
+         * Set this option to false (recommended) if you wish to process untrusted documents.
+         * This setting may increase the risk of system exploit.
+         * Do not change this settings without understanding the consequences.
+         * Additional documentation is available on the dompdf wiki at:
+         * https://github.com/dompdf/dompdf/wiki
          *
          * @var bool
          */
         "enable_php" => false,
 
         /**
-         * Enable inline Javascript
+         * Rnable inline JavaScript
          *
-         * If this setting is set to true then DOMPDF will automatically insert
-         * JavaScript code contained within <script type="text/javascript"> ... </script> tags.
+         * If this setting is set to true then DOMPDF will automatically insert JavaScript code contained
+         * within <script type="text/javascript"> ... </script> tags as written into the PDF.
+         * NOTE: This is PDF-based JavaScript to be executed by the PDF viewer,
+         * not browser-based JavaScript executed by Dompdf.
          *
          * @var bool
          */
@@ -255,21 +248,24 @@ return array(
         /**
          * Enable remote file access
          *
-         * If this setting is set to true, DOMPDF will access remote sites for
-         * images and CSS files as required.
-         * This is required for part of test case www/test/image_variants.html through www/examples.php
+         *  If this setting is set to true, DOMPDF will access remote sites for
+         *  images and CSS files as required.
          *
-         * Attention!
-         * This can be a security risk, in particular in combination with DOMPDF_ENABLE_PHP and
-         * allowing remote access to dompdf.php or on allowing remote html code to be passed to
-         * $dompdf = new DOMPDF(, $dompdf->load_html(...,
-         * This allows anonymous users to download legally doubtful internet content which on
-         * tracing back appears to being downloaded by your server, or allows malicious php code
-         * in remote html pages to be executed by your server with your account privileges.
+         *  ==== IMPORTANT ====
+         *  This can be a security risk, in particular in combination with isPhpEnabled and
+         *  allowing remote html code to be passed to $dompdf = new DOMPDF(); $dompdf->load_html(...);
+         *  This allows anonymous users to download legally doubtful internet content which on
+         *  tracing back appears to being downloaded by your server, or allows malicious php code
+         *  in remote html pages to be executed by your server with your account privileges.
+         *
+         *  This setting may increase the risk of system exploit. Do not change
+         *  this settings without understanding the consequences. Additional
+         *  documentation is available on the dompdf wiki at:
+         *  https://github.com/dompdf/dompdf/wiki
          *
          * @var bool
          */
-        "enable_remote" => true,
+        "enable_remote" => false,
 
         /**
          * List of allowed remote hosts

--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -96,6 +96,11 @@ return array(
             "https://" => ["rules" => []]
         ],
 
+        /**
+         * Operational artifact (log files, temporary files) path validation
+         */
+         'artifactPathValidation' => null,
+
          /**
           * @var string
           */
@@ -265,6 +270,20 @@ return array(
          * @var bool
          */
         "enable_remote" => true,
+
+        /**
+         * List of allowed remote hosts
+         *
+         * Each value of the array must be a valid hostname.
+         *
+         * This will be used to filter which resources can be loaded in combination with
+         * isRemoteEnabled. If enable_remote is FALSE, then this will have no effect.
+         *
+         * Leave to NULL to allow any remote host.
+         *
+         * @var array|null
+         */
+        'allowed_remote_hosts' => null,
 
         /**
          * A ratio applied to the fonts height to be more like browsers' line height

--- a/readme.md
+++ b/readme.md
@@ -91,9 +91,10 @@ Available options and their defaults:
 * __dpi__: 96 _(available in config/dompdf.php)_
 * __fontHeightRatio__: 1.1 _(available in config/dompdf.php)_
 * __isPhpEnabled__: false _(available in config/dompdf.php)_
-* __isRemoteEnabled__: true _(available in config/dompdf.php)_
+* __isRemoteEnabled__: false _(available in config/dompdf.php)_
 * __isJavascriptEnabled__: true _(available in config/dompdf.php)_
-* __isHtml5ParserEnabled__: false _(available in config/dompdf.php)_
+* __isHtml5ParserEnabled__: true _(available in config/dompdf.php)_
+* __allowedRemoteHosts__: null _(available in config/dompdf.php)_
 * __isFontSubsettingEnabled__: false _(available in config/dompdf.php)_
 * __debugPng__: false
 * __debugKeepTemp__: false
@@ -107,6 +108,9 @@ Available options and their defaults:
 * __pdflibLicense__: ""
 * __adminUsername__: "user"
 * __adminPassword__: "password"
+* __artifactPathValidation__: null _(available in config/dompdf.php)_
+
+#### Note: Since 3.x the remote access is disabled by default, to provide more security. Use with caution!
 
 ### Tip: UTF-8 support
 In your templates, set the UTF-8 Metatag:


### PR DESCRIPTION
- Changes the default security settings to be more secure (disable remote access by default)
- Drop old Laravel versions
- Bump major version because of possible changes in dompdf 3