### PR TITLE
Check filename, add fallback filename

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,5 +9,5 @@ parameters:
     level: 8
     ignoreErrors:
         # This is a global alias that cannot be detected by Larastan.
-        - '#Call to static method loadHtml\(\) on an unknown class PDF\.#'
-        - '#Call to static method loadHtml\(\) on an unknown class Pdf\.#'
+        - '#Call to static method loadHTML\(\) on an unknown class PDF\.#'
+        - '#Call to static method loadHTML\(\) on an unknown class Pdf\.#'

--- a/src/PDF.php
+++ b/src/PDF.php
@@ -11,6 +11,8 @@ use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 
 /**
  * A Laravel wrapper for Dompdf
@@ -210,9 +212,11 @@ class PDF
     public function download(string $filename = 'document.pdf'): Response
     {
         $output = $this->output();
+        $fallback = $this->fallbackName($filename);
+
         return new Response($output, 200, [
             'Content-Type' => 'application/pdf',
-            'Content-Disposition' =>  'attachment; filename="' . $filename . '"',
+            'Content-Disposition' => HeaderUtils::makeDisposition('attachment', $filename, $fallback),
             'Content-Length' => strlen($output),
         ]);
     }
@@ -223,9 +227,12 @@ class PDF
     public function stream(string $filename = 'document.pdf'): Response
     {
         $output = $this->output();
+        $fallback = $this->fallbackName($filename);
+
+
         return new Response($output, 200, [
             'Content-Type' => 'application/pdf',
-            'Content-Disposition' =>  'inline; filename="' . $filename . '"',
+            'Content-Disposition' => HeaderUtils::makeDisposition('inline', $filename, $fallback),
         ]);
     }
 
@@ -300,5 +307,13 @@ class PDF
         }
 
         throw new \UnexpectedValueException("Method [{$method}] does not exist on PDF instance.");
+    }
+
+    /**
+     * Make a safe fallback filename
+     */
+    protected function fallbackName(string $filename): string
+    {
+        return str_replace('%', '', Str::ascii($filename));
     }
 }

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -10,7 +10,7 @@ class PdfTest extends TestCase
 {
     public function testAlias(): void
     {
-        $pdf = \Pdf::loadHtml('<h1>Test</h1>');
+        $pdf = \Pdf::loadHTML('<h1>Test</h1>');
         /** @var Response $response */
         $response = $pdf->download('test.pdf');
 
@@ -22,7 +22,7 @@ class PdfTest extends TestCase
 
     public function testAliasCaps(): void
     {
-        $pdf = \PDF::loadHtml('<h1>Test</h1>');
+        $pdf = \PDF::loadHTML('<h1>Test</h1>');
         /** @var Response $response */
         $response = $pdf->download('test.pdf');
 
@@ -34,7 +34,7 @@ class PdfTest extends TestCase
 
     public function testFacade(): void
     {
-        $pdf = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        $pdf = Facade\Pdf::loadHTML('<h1>Test</h1>');
         /** @var Response $response */
         $response = $pdf->download('test.pdf');
 
@@ -46,7 +46,7 @@ class PdfTest extends TestCase
 
     public function testDownload(): void
     {
-        $pdf = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        $pdf = Facade\Pdf::loadHTML('<h1>Test</h1>');
         /** @var Response $response */
         $response = $pdf->download('test.pdf');
 
@@ -58,7 +58,7 @@ class PdfTest extends TestCase
 
     public function testStream(): void
     {
-        $pdf = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        $pdf = Facade\Pdf::loadHTML('<h1>Test</h1>');
         /** @var Response $response */
         $response = $pdf->stream('test.pdf');
 
@@ -82,7 +82,7 @@ class PdfTest extends TestCase
 
     public function testQuoteFilename(): void
     {
-        $pdf = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        $pdf = Facade\Pdf::loadHTML('<h1>Test</h1>');
         /** @var Response $response */
         $response = $pdf->download('Test file.pdf');
 
@@ -94,7 +94,7 @@ class PdfTest extends TestCase
 
     public function testFallbackFilename(): void
     {
-        $pdf = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        $pdf = Facade\Pdf::loadHTML('<h1>Test</h1>');
         /** @var Response $response */
         $response = $pdf->download('Test%file.pdf');
 
@@ -154,8 +154,8 @@ class PdfTest extends TestCase
 
     public function testMultipleInstances(): void
     {
-        $pdf1 = Facade\Pdf::loadHtml('<h1>Test</h1>');
-        $pdf2 = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        $pdf1 = Facade\Pdf::loadHTML('<h1>Test</h1>');
+        $pdf2 = Facade\Pdf::loadHTML('<h1>Test</h1>');
 
         $pdf1->getDomPDF()->setBaseHost('host1');
         $pdf2->getDomPDF()->setBaseHost('host2');

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -17,9 +17,9 @@ class PdfTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertNotEmpty($response->getContent());
         $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
-        $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=test.pdf', $response->headers->get('Content-Disposition'));
     }
-    
+
     public function testAliasCaps(): void
     {
         $pdf = \PDF::loadHtml('<h1>Test</h1>');
@@ -29,7 +29,7 @@ class PdfTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertNotEmpty($response->getContent());
         $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
-        $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=test.pdf', $response->headers->get('Content-Disposition'));
     }
 
     public function testFacade(): void
@@ -41,7 +41,7 @@ class PdfTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertNotEmpty($response->getContent());
         $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
-        $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=test.pdf', $response->headers->get('Content-Disposition'));
     }
 
     public function testDownload(): void
@@ -53,7 +53,7 @@ class PdfTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertNotEmpty($response->getContent());
         $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
-        $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=test.pdf', $response->headers->get('Content-Disposition'));
     }
 
     public function testStream(): void
@@ -65,7 +65,7 @@ class PdfTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertNotEmpty($response->getContent());
         $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
-        $this->assertEquals('inline; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+        $this->assertEquals('inline; filename=test.pdf', $response->headers->get('Content-Disposition'));
     }
 
     public function testView(): void
@@ -77,7 +77,31 @@ class PdfTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertNotEmpty($response->getContent());
         $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
-        $this->assertEquals('attachment; filename="test.pdf"', $response->headers->get('Content-Disposition'));
+        $this->assertEquals('attachment; filename=test.pdf', $response->headers->get('Content-Disposition'));
+    }
+
+    public function testQuoteFilename(): void
+    {
+        $pdf = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        /** @var Response $response */
+        $response = $pdf->download('Test file.pdf');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertNotEmpty($response->getContent());
+        $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
+        $this->assertEquals('attachment; filename="Test file.pdf"', $response->headers->get('Content-Disposition'));
+    }
+
+    public function testFallbackFilename(): void
+    {
+        $pdf = Facade\Pdf::loadHtml('<h1>Test</h1>');
+        /** @var Response $response */
+        $response = $pdf->download('Test%file.pdf');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertNotEmpty($response->getContent());
+        $this->assertEquals('application/pdf', $response->headers->get('Content-Type'));
+        $this->assertEquals("attachment; filename=Testfile.pdf; filename*=utf-8''Test%25file.pdf", $response->headers->get('Content-Disposition'));
     }
 
     public function testSaveOnDisk(): void


### PR DESCRIPTION
Use HeaderUtils to make the disposition. Add a fallback file to make sure the name is always valid.

Fixes #1026
