### PR TITLE
Redirect rendering issues by adding `contact_links`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report CSS/HTML Bug
+    url: https://github.com/dompdf/dompdf/issues/new?title=[CSS/HTML]:%20
+    about: 'Any issues with PDF rendering are not directly related to this package, should be reported to dompdf/dompdf'
+  - name: Report FONTs/Characters/Encoding Bug
+    url: https://github.com/dompdf/dompdf/issues/new?title=[FONTs]:%20
+    about: 'Any issues with fonts rendering are not directly related to this package, should be reported to dompdf/dompdf'
+  - name: Feature request
+    url: https://github.com/dompdf/dompdf/discussions/new?category=ideas&title=[ENHANCEMENT]:%20
+    about: 'For ideas or feature requests, start a new discussion'
+  - name: Support Questions & Other
+    url: https://github.com/dompdf/dompdf/discussions/new?category=q-a&title=[SUPPORT]:%20
+    about: 'This space is only for reporting bugs. If you have a question or need help use discussions, click:'


### PR DESCRIPTION
This PR adds redirects to dompdf/dompdf, in this way, rendering problems can be addressed more efficiently.
![image](https://github.com/barryvdh/laravel-dompdf/assets/4933954/a913f9bb-e8a7-4a31-8ddb-7c8fdd71617e)
