### PR TITLE
Update allowed_protocols config for compatibility with Dompdf v3.1

### DIFF
--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -91,6 +91,7 @@ return [
          * @var array
          */
         'allowed_protocols' => [
+            'data://' => ['rules' => []],
             'file://' => ['rules' => []],
             'http://' => ['rules' => []],
             'https://' => ['rules' => []],

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -163,4 +163,14 @@ class PdfTest extends TestCase
         $this->assertEquals('host1', $pdf1->getDomPDF()->getBaseHost());
         $this->assertEquals('host2', $pdf2->getDomPDF()->getBaseHost());
     }
+
+    public function testDataImage(): void
+    {
+        $pdf = Facade\Pdf::loadHTML('<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAEklEQVR4nGP8z4APMOGVHbHSAEEsAROxCnMTAAAAAElFTkSuQmCC" />');
+        $response = $pdf->download('test.pdf');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertNotEmpty($response->getContent());
+        $this->assertEquals(1424, strlen($response->getContent()));
+    }
 }


### PR DESCRIPTION
Implements the fix described in https://github.com/barryvdh/laravel-dompdf/issues/1070