### PR TITLE
Fix typo in dompdf.php comment

### DIFF
--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -236,7 +236,7 @@ return [
         'enable_php' => false,
 
         /**
-         * Rnable inline JavaScript
+         * Enable inline JavaScript
          *
          * If this setting is set to true then DOMPDF will automatically insert JavaScript code contained
          * within <script type="text/javascript"> ... </script> tags as written into the PDF.


### PR DESCRIPTION
## Fix typo in comment

Just spotted a small typo in the dompdf config file - "Rnable" should be "Enable" for the JavaScript comment.

### What changed
- Fixed the comment from "Rnable inline JavaScript" to "Enable inline JavaScript"

Just a tiny documentation fix, nothing functional.

---
PS: 
Hey Barry! 👋 Thanks so much for all your work on this package. Really appreciate you keeping this awesome tool going strong! Figured I'd fix this little typo I noticed while browsing the release note. Keep up the great work! 🚀